### PR TITLE
Kakao Login 기능 추가

### DIFF
--- a/AllOfSoccer/Application/AppDelegate.swift
+++ b/AllOfSoccer/Application/AppDelegate.swift
@@ -7,9 +7,12 @@
 
 import UIKit
 import AuthenticationServices
+import KakaoSDKAuth
+import KakaoSDKUser
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         appleIDProvider.getCredentialState(forUserID: "") { (credentialState, error) in
@@ -32,6 +35,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             print("Revoked Notification")
         }
         return true
+    }
+
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        if (AuthApi.isKakaoTalkLoginUrl(url)) {
+            return AuthController.handleOpenUrl(url: url)
+        }
+
+        return false
     }
 
     // MARK: UISceneSession Lifecycle

--- a/AllOfSoccer/Login/SignInViewController.swift
+++ b/AllOfSoccer/Login/SignInViewController.swift
@@ -7,9 +7,24 @@
 
 import UIKit
 import AuthenticationServices
+import KakaoSDKAuth
 
 class SignInViewController: UIViewController {
     @IBOutlet weak var signInView: UIView?
+
+    // viewmodel 브랜치안에 login 관련 코드가 있어 나중에 충돌이 발생할 수 있으므로 주석처리 해놓음
+    // 추후 사용할거임
+//    @IBAction func login() {
+//        AuthApi.shared.loginWithKakaoAccount { oauthToken, error in
+//            if let error = error {
+//                print(error)
+//            } else {
+//                print("loginWithKakaoAccount() success.")
+//                // do something
+//                _ = oauthToken
+//            }
+//        }
+//    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/AllOfSoccer/SupporttingFiles/Info.plist
+++ b/AllOfSoccer/SupporttingFiles/Info.plist
@@ -16,8 +16,24 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao6e18a0246f1f3ae3b3682e5744829bd6</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/Podfile
+++ b/Podfile
@@ -7,6 +7,7 @@ target 'AllOfSoccer' do
 
   # Pods for AllOfSoccer
   pod "SearchTextField"
-  pod "RangeSeekSlider"	
+  pod "RangeSeekSlider"
+  pod "KakaoSDK"
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,20 +1,74 @@
 PODS:
+  - Alamofire (5.4.4)
+  - KakaoSDK (2.8.6):
+    - KakaoSDKAuth (= 2.8.6)
+    - KakaoSDKCommon (= 2.8.6)
+    - KakaoSDKLink (= 2.8.6)
+    - KakaoSDKNavi (= 2.8.6)
+    - KakaoSDKStory (= 2.8.6)
+    - KakaoSDKTalk (= 2.8.6)
+    - KakaoSDKTemplate (= 2.8.6)
+    - KakaoSDKUser (= 2.8.6)
+  - KakaoSDKAuth (2.8.6):
+    - KakaoSDKCommon (= 2.8.6)
+  - KakaoSDKCommon (2.8.6):
+    - KakaoSDKCommon/Common (= 2.8.6)
+    - KakaoSDKCommon/Network (= 2.8.6)
+  - KakaoSDKCommon/Common (2.8.6)
+  - KakaoSDKCommon/Network (2.8.6):
+    - Alamofire (~> 5.1)
+    - KakaoSDKCommon/Common (= 2.8.6)
+  - KakaoSDKLink (2.8.6):
+    - KakaoSDKCommon (= 2.8.6)
+    - KakaoSDKTemplate (= 2.8.6)
+  - KakaoSDKNavi (2.8.6):
+    - KakaoSDKCommon/Common (= 2.8.6)
+  - KakaoSDKStory (2.8.6):
+    - KakaoSDKUser (= 2.8.6)
+  - KakaoSDKTalk (2.8.6):
+    - KakaoSDKTemplate (= 2.8.6)
+    - KakaoSDKUser (= 2.8.6)
+  - KakaoSDKTemplate (2.8.6):
+    - KakaoSDKCommon/Common (= 2.8.6)
+  - KakaoSDKUser (2.8.6):
+    - KakaoSDKAuth (= 2.8.6)
   - RangeSeekSlider (1.8.0)
   - SearchTextField (1.2.4)
 
 DEPENDENCIES:
+  - KakaoSDK
   - RangeSeekSlider
   - SearchTextField
 
 SPEC REPOS:
   trunk:
+    - Alamofire
+    - KakaoSDK
+    - KakaoSDKAuth
+    - KakaoSDKCommon
+    - KakaoSDKLink
+    - KakaoSDKNavi
+    - KakaoSDKStory
+    - KakaoSDKTalk
+    - KakaoSDKTemplate
+    - KakaoSDKUser
     - RangeSeekSlider
     - SearchTextField
 
 SPEC CHECKSUMS:
+  Alamofire: f3b09a368f1582ab751b3fff5460276e0d2cf5c9
+  KakaoSDK: 29ca188341fbb8994586eac73c10209f3889b574
+  KakaoSDKAuth: 53e747a3bf343a3f3e87b14478d5a865d6c2acae
+  KakaoSDKCommon: 7e56600ff4c1bd82bed93fea4299b5a37f47e6a5
+  KakaoSDKLink: 59a6bdf7abd915aacba4c2671672ffe9654798dd
+  KakaoSDKNavi: 4df155701e60822a9f4426630ae2a38328e779be
+  KakaoSDKStory: afd97ece5b6b2a6d342533397654cea773954664
+  KakaoSDKTalk: d5b5a21281fa370f7d273a9140e82ba54aa9531a
+  KakaoSDKTemplate: 23bdcba233dce91fc948353c3b03d94f928d87d1
+  KakaoSDKUser: e79480355fa789f42e628dfba359fc21e9914f4c
   RangeSeekSlider: 650b11fa1edcb92e1e0ede797669d98622570fb5
   SearchTextField: 40dc3cc57def5a211f263cac263622c163bbc25a
 
-PODFILE CHECKSUM: a7c6226865fd7284a98eabbfac649e9cf95a9181
+PODFILE CHECKSUM: 8d5a4aa19b5d433ceb6a7263ec1054f0e9bbbfac
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
로그인 방법을 총 2가지 사용할 것이기 때문에 Kakao 로그인 SDK를 추가해주고, 가이드라인에 나온 기본 코드를 추가해줬다.
향후 viewmodel 브랜치랑 합친 후에 UI 및 accesstoken을 가져오는 로직을 구현할 생각이다.